### PR TITLE
Fix the auto-version workflow

### DIFF
--- a/.github/workflows/commit-message-validator.yml
+++ b/.github/workflows/commit-message-validator.yml
@@ -1,0 +1,16 @@
+name: "Commit message validation on pull request"
+
+on: pull_request
+
+jobs:
+  commit-message-validation:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Commit message validation
+        uses: lumapps/commit-message-validator@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-build.yml
+++ b/.github/workflows/lint-build.yml
@@ -10,7 +10,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -29,7 +30,8 @@ jobs:
     needs: lint
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,8 @@ jobs:
     needs: bump-version
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,14 +2,14 @@ name: Release
 
 on:
   push:
-    tags:
-      - 'v*.*.*'
+    branches:
+      - main
 
 jobs:
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: build
+    needs: bump-version
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -9,15 +9,17 @@ jobs:
   bump-version:
     name: Bump Version and Tag
     runs-on: ubuntu-latest
+    needs: build
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Bump version
-        uses: phips28/gh-action-bump-version@v11
+      - name: Bump version and push tag
+        uses: hennejg/github-tag-action@v4
         with:
-          tag-prefix: "v"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag_prefix: "v"
+          release_branches: main

--- a/README.md
+++ b/README.md
@@ -5,8 +5,28 @@ The name Maple Pie, a Canadian dessert, comes from the association of maple with
 
 The project is in its infancy. The intent at this time is to construct commands to handle API calls to various endpoints. The code is written in Golang.
 
+# For developers
+
+[![semantic-release: angular](https://img.shields.io/badge/semantic--release-angular-e10079?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
+
 ## Repository structure
 
 This repository is structured following [the "Organizing a Go module" guide for a Server Project][go-org-guide-server].
 
 [go-org-guide-server]: https://go.dev/doc/modules/layout#server-project
+
+## Versioning & commit message conventions
+
+Automated Versioning and Release occurs exclusively on the `main` branch and is handled by the GitHub Actions CI pipeline.
+
+To increase the version, commit message headers must follow [`semantic-release`][semantic-release] conventions, which in turn follow [Angular Commit Message Conventions][angular-conv]. This convention is partially enforced by the GitHub Actions CI pipeline.
+
+What is not enforced is the free-form change descriptions. Please self-enforce these rules:
+- use the imperative, present tense: ex. "change" not "changed" nor "changes" nor "changing"
+- don't capitalize first letter
+- no dot (.) at the end
+
+In the near future, an issue tracker may be introduced to be referenced in the footer of the commit messages.
+
+[semantic-release]: https://github.com/semantic-release/semantic-release
+[angular-conv]: https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines


### PR DESCRIPTION
change the action used for auto-versioning in the CI pipeline. Mistakenly used an action for npm versioning in last PR.

some other minor formatting and a README update included