### PR TITLE
chore(github-workflows): use modern tag Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,11 +41,13 @@ jobs:
           name: maplepie-binaries
           path: dist/*.zip
 
-  bump-version:
-    name: Bump Version and Tag
+  release:
+    name: Version, Tag, Release
     runs-on: ubuntu-latest
     needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code
@@ -54,21 +56,10 @@ jobs:
           fetch-depth: 0
 
       - name: Bump version and push tag
-        uses: hennejg/github-tag-action@v4
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          tag_prefix: "v"
-          release_branches: main
-
-  release:
-    name: Create GitHub Release
-    runs-on: ubuntu-latest
-    needs: bump-version
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
 
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Testing
+name: Test
 
 on:
   push:


### PR DESCRIPTION
change CI job to use https://github.com/mathieudutour/github-tag-action instead of an obsolete fork of this action