### PR TITLE
chore(github-workflows): use custom repo secret for tagging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,4 +59,4 @@ jobs:
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.PAT_FOR_TAGGING }}


### PR DESCRIPTION
change secret for workflow tagging